### PR TITLE
generate protoc with grpc-web plugin before ts-node plugin

### DIFF
--- a/scripts/compile-proto-js
+++ b/scripts/compile-proto-js
@@ -23,14 +23,15 @@ ${GRPC_TOOLS_NODE_PROTOC} \
 
 ${GRPC_TOOLS_NODE_PROTOC} \
   --js_out=import_style=commonjs,binary:./generated/js \
-  --plugin=protoc-gen-ts="${PROTOC_GEN_TS_PATH}" \
-  --ts_out=grpc_js:./generated/js \
+  --grpc-web_out=import_style=typescript,mode=grpcwebtext:./generated/js \
+  --plugin=protoc-gen-grpc-web=${GRPC_WEB_PLUGIN} \
   *.proto
 
 ${GRPC_TOOLS_NODE_PROTOC} \
   --js_out=import_style=commonjs,binary:./generated/js \
-  --grpc-web_out=import_style=typescript,mode=grpcwebtext:./generated/js \
-  --plugin=protoc-gen-grpc-web=${GRPC_WEB_PLUGIN} \
+  --plugin=protoc-gen-ts="${PROTOC_GEN_TS_PATH}" \
+  --ts_out=grpc_js:./generated/js \
   *.proto
+
 
 popd


### PR DESCRIPTION
in `compile-proto-js` script:
it seems that **protoc-gen-grpc-web** && **protoc-gen-ts** does not use the same indentation format. It leads to weird behavior in ts generated files (currently, `TradeType` is becoming `radeType`...).

FIX: use `protoc-gen-grpc-web` before `protoc-gen-ts`.

@tiero please review