### PR TITLE
Update Fixed fee, Balance & MarketPriceReply

### DIFF
--- a/types.proto
+++ b/types.proto
@@ -3,10 +3,11 @@ option go_package = "github.com/tdex-network/tdex-protobuf/generated/go/types";
 
 // Custom Types
 message Fee {
-  int64 basis_point = 2;
+  int64 basis_point = 1;
+  Fixed fixed = 2;
 }
 
-message FixedFee {
+message Fixed {
   int64 base_fee = 1;
   int64 quote_fee = 2;
 }
@@ -29,7 +30,6 @@ message Market {
 message MarketWithFee {
   Market market = 1;
   Fee fee = 2;
-  FixedFee fixed_fee = 3;
 }
 
 message Price {

--- a/types.proto
+++ b/types.proto
@@ -6,6 +6,11 @@ message Fee {
   int64 basis_point = 2;
 }
 
+message FixedFee {
+  int64 base_fee = 1;
+  int64 quote_fee = 2;
+}
+
 message Balance {
   int64 base_amount = 1;
   int64 quote_amount = 2;
@@ -24,6 +29,7 @@ message Market {
 message MarketWithFee {
   Market market = 1;
   Fee fee = 2;
+  FixedFee fixed_fee = 3;
 }
 
 message Price {

--- a/types.proto
+++ b/types.proto
@@ -3,8 +3,8 @@ option go_package = "github.com/tdex-network/tdex-protobuf/generated/go/types";
 
 // Custom Types
 message Fee {
-  int64 basis_point = 1;
-  Fixed fixed = 2;
+  int64 basis_point = 2;
+  Fixed fixed = 3;
 }
 
 message Fixed {

--- a/types.proto
+++ b/types.proto
@@ -13,8 +13,8 @@ message Fixed {
 }
 
 message Balance {
-  int64 base_amount = 1;
-  int64 quote_amount = 2;
+  uint64 base_amount = 1;
+  uint64 quote_amount = 2;
 }
 
 message BalanceWithFee {
@@ -42,6 +42,7 @@ message PriceWithFee {
   Fee fee = 2;
   uint64 amount = 3;
   string asset = 4;
+  Balance balance = 5;
 }
 
 message AddressWithBlindingKey {


### PR DESCRIPTION
This adds a fixed fee to the MarketWIthFee message in order to let the operator specify a fixed fee amount (for both market assets) to be charged to incoming trades.

This also updates the type of the Balance message to unit64 and adds a Balance message field to the MarketPriceReply.

Please @tiero review this.