### PR TITLE
Update price type

### DIFF
--- a/types.proto
+++ b/types.proto
@@ -34,8 +34,8 @@ message MarketWithFee {
 }
 
 message Price {
-  float base_price = 1;
-  float quote_price = 2;
+  double base_price = 1;
+  double quote_price = 2;
 }
 
 message PriceWithFee {

--- a/types.proto
+++ b/types.proto
@@ -34,8 +34,10 @@ message MarketWithFee {
 }
 
 message Price {
-  double base_price = 1;
-  double quote_price = 2;
+  float base_price_deprecated = 1;
+  float quote_price_deprecated = 2;
+  double base_price = 3;
+  double quote_price = 4;
 }
 
 message PriceWithFee {


### PR DESCRIPTION
This update price type to double, which go converts to float64, this is needed cause of daemon [issue](https://github.com/tdex-network/tdex-daemon/issues/550) happening in [here](https://github.com/tdex-network/tdex-daemon/blob/1cfcd449e261f9481818889a948ea265d9a82122/cmd/tdex/market.go#L680)

@tiero please review.