### PR TITLE
Add api for market spot price

### DIFF
--- a/api-spec/openapi/swagger/tdex/v1/trade.swagger.json
+++ b/api-spec/openapi/swagger/tdex/v1/trade.swagger.json
@@ -49,6 +49,39 @@
         ]
       }
     },
+    "/v1/market/price": {
+      "post": {
+        "summary": "GetMarketPrice retutns the spot price for the requested market and its\nminimum tradable amount of base asset.",
+        "operationId": "TradeService_GetMarketPrice",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMarketPriceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMarketPriceRequest"
+            }
+          }
+        ],
+        "tags": [
+          "TradeService"
+        ]
+      }
+    },
     "/v1/markets": {
       "post": {
         "summary": "ListMarkets lists all the markets open for trading.",
@@ -285,6 +318,27 @@
       "properties": {
         "balance": {
           "$ref": "#/definitions/v1BalanceWithFee"
+        }
+      }
+    },
+    "v1GetMarketPriceRequest": {
+      "type": "object",
+      "properties": {
+        "market": {
+          "$ref": "#/definitions/v1Market"
+        }
+      }
+    },
+    "v1GetMarketPriceResponse": {
+      "type": "object",
+      "properties": {
+        "spotPrice": {
+          "type": "number",
+          "format": "double"
+        },
+        "minTradableAmount": {
+          "type": "string",
+          "format": "uint64"
         }
       }
     },

--- a/api-spec/protobuf/tdex/v1/trade.proto
+++ b/api-spec/protobuf/tdex/v1/trade.proto
@@ -23,6 +23,15 @@ service TradeService {
     };
   }
 
+  // GetMarketPrice retutns the spot price for the requested market and its
+  // minimum tradable amount of base asset.
+  rpc GetMarketPrice(GetMarketPriceRequest) returns (GetMarketPriceResponse){
+    option (google.api.http) = {
+      post: "/v1/market/price"
+      body: "*"
+    };
+  }
+
   // PreviewTrade returns a counter amount and asset in response to the
   // provided ones and a trade type for a market.
   //
@@ -69,6 +78,12 @@ message ListMarketsResponse { repeated MarketWithFee markets = 1; }
 
 message GetMarketBalanceRequest { Market market = 1; }
 message GetMarketBalanceResponse { BalanceWithFee balance = 1; }
+
+message GetMarketPriceRequest { Market market = 1; }
+message GetMarketPriceResponse {
+  double spot_price = 1;
+  uint64 min_tradable_amount = 2;
+}
 
 message PreviewTradeRequest {
   Market market = 1;


### PR DESCRIPTION
This adds a new API to retrieve the spot price of a market and the min tradable amount of base asset.

Please @tiero review this.