### PR TITLE
Revert changes to swap message

### DIFF
--- a/api-spec/openapi/swagger/tdex/v1/trade.swagger.json
+++ b/api-spec/openapi/swagger/tdex/v1/trade.swagger.json
@@ -497,13 +497,6 @@
             "format": "byte"
           },
           "description": "In case of a confidential transaction the blinding key of each confidential\noutput is included. Each blinding key is identified by the output script\nhex encoded."
-        },
-        "unblindedInputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1UnblindedInput"
-          },
-          "description": "In case of psetv2 transaction, the original list of trader's unblinded inputs,\nincluding also those of the inputs added by the provider."
         }
       }
     },
@@ -590,13 +583,6 @@
             "format": "byte"
           },
           "description": "In case of a confidential psetv0 transaction the blinding key of each\nconfidential output is included. Each blinding key is identified by the\noutput script hex encoded."
-        },
-        "unblindedInputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1UnblindedInput"
-          },
-          "description": "In case of psetv2 transaction, the list of trader's unblinded inputs data,\neven in case they are unconfidential."
         }
       }
     },
@@ -607,29 +593,6 @@
         "TRADE_TYPE_SELL"
       ],
       "default": "TRADE_TYPE_BUY"
-    },
-    "v1UnblindedInput": {
-      "type": "object",
-      "properties": {
-        "index": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "asset": {
-          "type": "string"
-        },
-        "amount": {
-          "type": "string",
-          "format": "uint64"
-        },
-        "assetBlinder": {
-          "type": "string"
-        },
-        "amountBlinder": {
-          "type": "string"
-        }
-      },
-      "title": "Custom Types"
     }
   }
 }

--- a/api-spec/openapi/swagger/tdex/v1/trade.swagger.json
+++ b/api-spec/openapi/swagger/tdex/v1/trade.swagger.json
@@ -290,7 +290,8 @@
         "fixed": {
           "$ref": "#/definitions/v1Fixed"
         }
-      }
+      },
+      "title": "Custom Types"
     },
     "v1Fixed": {
       "type": "object",

--- a/api-spec/protobuf/tdex/v1/swap.proto
+++ b/api-spec/protobuf/tdex/v1/swap.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package tdex.v1;
 
-import "tdex/v1/types.proto";
-
 message SwapRequest {
   // Random unique identifier for the current message
   string id = 1;
@@ -25,9 +23,6 @@ message SwapRequest {
   // confidential output is included. Each blinding key is identified by the
   // output script hex encoded.
   map<string, bytes> output_blinding_key = 8;
-  // In case of psetv2 transaction, the list of trader's unblinded inputs data,
-  // even in case they are unconfidential.
-  repeated UnblindedInput unblinded_inputs = 9;
 }
 
 message SwapAccept {
@@ -46,9 +41,6 @@ message SwapAccept {
   // output is included. Each blinding key is identified by the output script
   // hex encoded.
   map<string, bytes> output_blinding_key = 5;
-  // In case of psetv2 transaction, the original list of trader's unblinded inputs,
-  // including also those of the inputs added by the provider.
-  repeated UnblindedInput unblinded_inputs = 6;
 }
 
 message SwapComplete {

--- a/api-spec/protobuf/tdex/v1/types.proto
+++ b/api-spec/protobuf/tdex/v1/types.proto
@@ -3,14 +3,6 @@ syntax = "proto3";
 package tdex.v1;
 
 // Custom Types
-message UnblindedInput {
-  uint32 index = 1;
-  string asset = 2;
-  uint64 amount = 3;
-  string asset_blinder = 4;
-  string amount_blinder = 5;
-}
-
 message Fee {
   int64 basis_point = 1;
   Fixed fixed = 2;


### PR DESCRIPTION
This reverts the changes introduced by a previous PR, ie. removes the new message `UnblindedInput` and the new field `repeated UnblindedInput unblinded_inputs` from swap request/accept message.

These changes will be applied to proto v2.

Please @tiero review this.