### PR TITLE
Move trading fees from swap to trade

### DIFF
--- a/api-spec/openapi/swagger/tdex/v2/trade.swagger.json
+++ b/api-spec/openapi/swagger/tdex/v2/trade.swagger.json
@@ -442,6 +442,13 @@
         },
         "swapRequest": {
           "$ref": "#/definitions/tdexv2SwapRequest"
+        },
+        "feeAmount": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "feeAsset": {
+          "type": "string"
         }
       }
     },
@@ -551,15 +558,6 @@
         "transaction": {
           "type": "string",
           "title": "The proposer's unsigned transaction in PSET v2 format (base64 string)"
-        },
-        "feeAmount": {
-          "type": "string",
-          "format": "uint64",
-          "description": "The fee amount charged to the proposer by the provider."
-        },
-        "feeAsset": {
-          "type": "string",
-          "description": "The asset hash of the fee charged to the proposer."
         },
         "unblindedInputs": {
           "type": "array",

--- a/api-spec/protobuf/tdex/v2/swap.proto
+++ b/api-spec/protobuf/tdex/v2/swap.proto
@@ -17,13 +17,9 @@ message SwapRequest {
   string asset_r = 5;
   // The proposer's unsigned transaction in PSET v2 format (base64 string)
   string transaction = 6;
-  // The fee amount charged to the proposer by the provider.
-  uint64 fee_amount = 7 [jstype = JS_STRING];
-  // The asset hash of the fee charged to the proposer.
-  string fee_asset = 8;
   // The list of trader's unblinded inputs data, even in case they are
   // unconfidential.
-  repeated UnblindedInput unblinded_inputs = 9;
+  repeated UnblindedInput unblinded_inputs = 7;
 }
 
 message SwapAccept {

--- a/api-spec/protobuf/tdex/v2/trade.proto
+++ b/api-spec/protobuf/tdex/v2/trade.proto
@@ -101,6 +101,8 @@ message ProposeTradeRequest {
   Market market = 1;
   TradeType type = 2;
   SwapRequest swap_request = 3;
+  uint64 fee_amount = 4 [jstype = JS_STRING];
+  string fee_asset = 5;
 }
 message ProposeTradeResponse {
   SwapAccept swap_accept = 1;


### PR DESCRIPTION
This updates protos according to latest changes on specs by moving the trading fees from SwapRequest to TradeProposeRequest.

Please @tiero review this.