### PR TITLE
Add liquidity info to market price response

### DIFF
--- a/api-spec/openapi/swagger/tdex/v2/trade.swagger.json
+++ b/api-spec/openapi/swagger/tdex/v2/trade.swagger.json
@@ -331,11 +331,15 @@
         "minTradableAmount": {
           "type": "string",
           "format": "uint64"
+        },
+        "balance": {
+          "$ref": "#/definitions/tdexv2Balance"
         }
       },
       "required": [
         "spotPrice",
-        "minTradableAmount"
+        "minTradableAmount",
+        "balance"
       ]
     },
     "tdexv2ListMarketsResponse": {

--- a/api-spec/protobuf/tdex/v2/trade.proto
+++ b/api-spec/protobuf/tdex/v2/trade.proto
@@ -87,6 +87,7 @@ message GetMarketPriceRequest { Market market = 1; }
 message GetMarketPriceResponse {
   double spot_price = 1 [(google.api.field_behavior) = REQUIRED];
   uint64 min_tradable_amount = 2 [jstype = JS_STRING, (google.api.field_behavior) = REQUIRED];
+  Balance balance = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 message PreviewTradeRequest {


### PR DESCRIPTION
This adds balance info to the market price response message for sake of completeness.

Please @tiero review.